### PR TITLE
Fix GameObject Interacts

### DIFF
--- a/WorldServer/World/Objects/GameObject.cs
+++ b/WorldServer/World/Objects/GameObject.cs
@@ -91,7 +91,8 @@ namespace WorldServer
                 Plr.QtsInterface.HandleEvent(Objective_Type.QUEST_USE_GO, Spawn.Entry, 1);
             }
 
-            Plr.TokInterface.AddTok(Info.Entry);
+            if (Spawn.Proto.TokUnlock != 0)
+                Plr.TokInterface.AddTok(Info.Entry);
 
             base.SendInteract(Plr, Menu);
         }


### PR DESCRIPTION
Fixed GameObject Interact error, was causing errors on emulator when this GameObject didn't had a ToKEntry.
