### PR TITLE
Fix for Quests that need items to be clicked  Better .Info on game objects

### DIFF
--- a/WorldServer/World/Interfaces/QuestsInterface.cs
+++ b/WorldServer/World/Interfaces/QuestsInterface.cs
@@ -401,7 +401,7 @@ namespace WorldServer
                             }
                             else if (Type == Objective_Type.QUEST_GET_ITEM)
                             {
-                                if (Objective.Objective.Item != null && Entry == Objective.Objective.Item.Entry)
+                                if (Objective.Objective.ObjID != null && Entry == uint.Parse(Objective.Objective.ObjID))
                                     CanAdd = true;
                             }
                             else if (Type == Objective_Type.QUEST_USE_GO)

--- a/WorldServer/World/Objects/GameObject.cs
+++ b/WorldServer/World/Objects/GameObject.cs
@@ -88,7 +88,8 @@ namespace WorldServer
 
             if (!IsDead)
             {
-                Plr.QtsInterface.HandleEvent(Objective_Type.QUEST_USE_GO, Spawn.Entry, 1);
+            Plr.QtsInterface.HandleEvent(Objective_Type.QUEST_USE_GO, Spawn.Proto.Entry, 1);
+            Plr.QtsInterface.HandleEvent(Objective_Type.QUEST_GET_ITEM, Spawn.Proto.Entry, 1);
             }
 
             if (Spawn.Proto.Name == "Mailbox") // Mailbox
@@ -100,6 +101,10 @@ namespace WorldServer
                 Plr.TokInterface.AddTok(Info.Entry);
 
             base.SendInteract(Plr, Menu);
+        }
+        public override string ToString()
+        {
+            return "SpawnId=" + Spawn.Guid + ",Entry=" + Spawn.Entry + ",Name=" + Name + ",Level=" + Level + ",Faction=" + Faction + ",Position :" + base.ToString();
         }
     }
 }


### PR DESCRIPTION
Fix for Quests that need items to be clicked 
2 things need to be done in sql 
1. update the objcetid in questsobjectivs to match the clickable item
like
UPDATE `test`.`quests_objectives` SET `ObjID`='561' WHERE `Guid`='2783';  // its 
2. to make the item clickable its kind of a hack
change Unks from 7680 0 14080 1312 706 563 to 7680 1 18079 1316 1228 19835
like
UPDATE `test`.`gameobject_protos` SET `Unks`='7680 1 18079 1316 1228 19835' WHERE `Entry`='561';

the example is form the destro quest Pillaging first quest hub
